### PR TITLE
perf(mixins): add performance-intensive mathematical operations and memory waste

### DIFF
--- a/src/main/java/com/wiyuka/prehistoric/mixin/GameRendererMixin.java
+++ b/src/main/java/com/wiyuka/prehistoric/mixin/GameRendererMixin.java
@@ -1,0 +1,27 @@
+package com.wiyuka.prehistoric.mixin;
+
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.renderer.GameRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GameRenderer.class)
+public class GameRendererMixin {
+    @Unique
+    private int prehistoric$fibonacciVision(int n) {
+        if (n <= 1) return n;
+        return prehistoric$fibonacciVision(n - 1) + prehistoric$fibonacciVision(n - 2);
+    }
+
+    @Inject(method = "render", at = @At("HEAD"))
+    public void prehistoricVisionOptimization(DeltaTracker deltaTracker, boolean renderLevel, CallbackInfo ci) {
+        int vision = prehistoric$fibonacciVision(40);
+        java.math.BigDecimal angle = new java.math.BigDecimal("0.0");
+        for (int i = 0; i < 1000; i++) {
+            angle = angle.add(java.math.BigDecimal.valueOf(Math.sin(i * 0.01)));
+        }
+    }
+}

--- a/src/main/java/com/wiyuka/prehistoric/mixin/MinecraftMixin.java
+++ b/src/main/java/com/wiyuka/prehistoric/mixin/MinecraftMixin.java
@@ -1,0 +1,35 @@
+package com.wiyuka.prehistoric.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.LinkedList;
+import java.util.function.BooleanSupplier;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftMixin {
+    @Unique
+    private static final LinkedList<byte[]> MEMORY_POOL = new LinkedList<>();
+    @Inject(method = "tickServer", at = @At("HEAD"))
+    public void preTickChildren(BooleanSupplier hasTimeLeft, CallbackInfo ci) {
+        System.gc();
+        byte[] waste = new byte[1024 * 1024];
+
+        if (MEMORY_POOL.size() < 100) {
+            MEMORY_POOL.add(waste);
+        }
+
+        for (int i = 0; i < 3; i++) {
+            System.gc();
+            try { Thread.sleep(1); } catch (InterruptedException e) {}
+        }
+
+        if (Math.random() < 0.01) {
+            MEMORY_POOL.clear();
+        }
+    }
+}

--- a/src/main/java/com/wiyuka/prehistoric/mixin/MthMixin.java
+++ b/src/main/java/com/wiyuka/prehistoric/mixin/MthMixin.java
@@ -8,38 +8,23 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.wiyuka.prehistoric.util.MathHelper;
-
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.function.*;
-
-import static com.wiyuka.prehistoric.util.MathHelper.averageSample;
 
 @Mixin(Mth.class)
 public class MthMixin {
 
     @Unique
     private static final MathContext MATH_CONTEXT = MathContext.DECIMAL128;
-    
-    /** The amount of calculations will be executed in {@link MathHelper#averageSample} */
-    @Unique
-    private static final long prehistoric$ROUND = 1 << 24; // Just a random number
 
-    @Inject(
-        method = "lerp(FFF)F",
-        at = @At("HEAD"),
-        cancellable = true
-    )
-    private static void preLerpFloat(float pDelta, float pStart, float pEnd, @NotNull CallbackInfoReturnable<Float> cir) {
-        cir.setReturnValue(averageSample(() -> {
-            BigDecimal delta = BigDecimal.valueOf(pDelta);
-            BigDecimal start = BigDecimal.valueOf(pStart);
-            BigDecimal end = BigDecimal.valueOf(pEnd);
-            
-            BigDecimal result = delta.multiply(end.subtract(start), MATH_CONTEXT).add(start, MATH_CONTEXT);
-            return result.floatValue();
-        }, prehistoric$ROUND));
+    @Unique
+    private static boolean prehistoric$inStaticInit = true;
+
+    static {
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException ignored) {}
+        prehistoric$inStaticInit = false;
     }
 
     @Inject(
@@ -48,14 +33,22 @@ public class MthMixin {
         cancellable = true
     )
     private static void preLerpDouble(double pDelta, double pStart, double pEnd, @NotNull CallbackInfoReturnable<Double> cir) {
-        cir.setReturnValue(averageSample(() -> {
-            BigDecimal delta = BigDecimal.valueOf(pDelta);
-            BigDecimal start = BigDecimal.valueOf(pStart);
-            BigDecimal end = BigDecimal.valueOf(pEnd);
-            
-            BigDecimal result = delta.multiply(end.subtract(start), MATH_CONTEXT).add(start, MATH_CONTEXT);
-            return result.doubleValue();
-        }, prehistoric$ROUND));
+        BigDecimal delta = BigDecimal.valueOf(pDelta);
+        BigDecimal start = BigDecimal.valueOf(pStart);
+        BigDecimal end = BigDecimal.valueOf(pEnd);
+
+        BigDecimal result = delta.multiply(end.subtract(start), MATH_CONTEXT).add(start, MATH_CONTEXT);
+
+        for (int i = 0; i < 100; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+            if (i % 20 == 0) {
+                try {
+                    Thread.sleep(0, 50);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.doubleValue());
     }
 
     @Inject(
@@ -64,16 +57,19 @@ public class MthMixin {
         cancellable = true
     )
     private static void preLengthSquared2D(double pXDistance, double pYDistance, CallbackInfoReturnable<Double> cir) {
-        cir.setReturnValue(averageSample(() -> {
-            BigDecimal x = BigDecimal.valueOf(pXDistance);
-            BigDecimal y = BigDecimal.valueOf(pYDistance);
-            
-            BigDecimal xSquared = x.multiply(x, MATH_CONTEXT);
-            BigDecimal ySquared = y.multiply(y, MATH_CONTEXT);
-            
-            BigDecimal result = xSquared.add(ySquared, MATH_CONTEXT);
-            return result.doubleValue();
-        }, prehistoric$ROUND));
+        BigDecimal x = BigDecimal.valueOf(pXDistance);
+        BigDecimal y = BigDecimal.valueOf(pYDistance);
+
+        BigDecimal xSquared = x.multiply(x, MATH_CONTEXT);
+        BigDecimal ySquared = y.multiply(y, MATH_CONTEXT);
+
+        BigDecimal result = xSquared.add(ySquared, MATH_CONTEXT);
+
+        for (int i = 0; i < 50; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+        }
+
+        cir.setReturnValue(result.doubleValue());
     }
 
     @Inject(
@@ -82,18 +78,21 @@ public class MthMixin {
         cancellable = true
     )
     private static void preLengthSquared3D(double pXDistance, double pYDistance, double pZDistance, CallbackInfoReturnable<Double> cir) {
-        cir.setReturnValue(averageSample(() -> {
-            BigDecimal x = BigDecimal.valueOf(pXDistance);
-            BigDecimal y = BigDecimal.valueOf(pYDistance);
-            BigDecimal z = BigDecimal.valueOf(pZDistance);
-            
-            BigDecimal xSquared = x.multiply(x, MATH_CONTEXT);
-            BigDecimal ySquared = y.multiply(y, MATH_CONTEXT);
-            BigDecimal zSquared = z.multiply(z, MATH_CONTEXT);
-            
-            BigDecimal result = xSquared.add(ySquared, MATH_CONTEXT).add(zSquared, MATH_CONTEXT);
-            return result.doubleValue();
-        }, prehistoric$ROUND));
+        BigDecimal x = BigDecimal.valueOf(pXDistance);
+        BigDecimal y = BigDecimal.valueOf(pYDistance);
+        BigDecimal z = BigDecimal.valueOf(pZDistance);
+
+        BigDecimal xSquared = x.multiply(x, MATH_CONTEXT);
+        BigDecimal ySquared = y.multiply(y, MATH_CONTEXT);
+        BigDecimal zSquared = z.multiply(z, MATH_CONTEXT);
+
+        BigDecimal result = xSquared.add(ySquared, MATH_CONTEXT).add(zSquared, MATH_CONTEXT);
+
+        for (int i = 0; i < 75; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+        }
+
+        cir.setReturnValue(result.doubleValue());
     }
 
     @Inject(
@@ -106,16 +105,24 @@ public class MthMixin {
             cir.setReturnValue(pMinimum);
             return;
         }
-        
-        cir.setReturnValue(averageSample(() -> {
-            float randomValue = pRandom.nextFloat();
-            BigDecimal delta = BigDecimal.valueOf(randomValue);
-            BigDecimal min = BigDecimal.valueOf(pMinimum);
-            BigDecimal max = BigDecimal.valueOf(pMaximum);
-            
-            BigDecimal result = delta.multiply(max.subtract(min), MATH_CONTEXT).add(min, MATH_CONTEXT);
-            return result.floatValue();
-        }, prehistoric$ROUND));
+
+        float randomValue = pRandom.nextFloat();
+        BigDecimal delta = BigDecimal.valueOf(randomValue);
+        BigDecimal min = BigDecimal.valueOf(pMinimum);
+        BigDecimal max = BigDecimal.valueOf(pMaximum);
+
+        BigDecimal result = delta.multiply(max.subtract(min), MATH_CONTEXT).add(min, MATH_CONTEXT);
+
+        for (int i = 0; i < 100; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+            if (i % 25 == 0) {
+                try {
+                    Thread.sleep(0, 50);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.floatValue());
     }
 
     @Inject(
@@ -128,16 +135,24 @@ public class MthMixin {
             cir.setReturnValue(pMinimum);
             return;
         }
-        
-        cir.setReturnValue(averageSample(() -> {
-            double randomValue = pRandom.nextDouble();
-            BigDecimal delta = BigDecimal.valueOf(randomValue);
-            BigDecimal min = BigDecimal.valueOf(pMinimum);
-            BigDecimal max = BigDecimal.valueOf(pMaximum);
-            
-            BigDecimal result = delta.multiply(max.subtract(min), MATH_CONTEXT).add(min, MATH_CONTEXT);
-            return result.doubleValue();
-        }, prehistoric$ROUND));
+
+        double randomValue = pRandom.nextDouble();
+        BigDecimal delta = BigDecimal.valueOf(randomValue);
+        BigDecimal min = BigDecimal.valueOf(pMinimum);
+        BigDecimal max = BigDecimal.valueOf(pMaximum);
+
+        BigDecimal result = delta.multiply(max.subtract(min), MATH_CONTEXT).add(min, MATH_CONTEXT);
+
+        for (int i = 0; i < 100; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+            if (i % 25 == 0) {
+                try {
+                    Thread.sleep(0, 50);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.doubleValue());
     }
 
     @Inject(
@@ -146,14 +161,265 @@ public class MthMixin {
         cancellable = true
     )
     private static void preNormal(net.minecraft.util.RandomSource pRandom, float pMean, float pDeviation, CallbackInfoReturnable<Float> cir) {
-        cir.setReturnValue(averageSample(() -> {
-            double gaussian = pRandom.nextGaussian();
-            BigDecimal gaussianBD = BigDecimal.valueOf(gaussian);
-            BigDecimal deviation = BigDecimal.valueOf(pDeviation);
-            BigDecimal mean = BigDecimal.valueOf(pMean);
-            
-            BigDecimal result = gaussianBD.multiply(deviation, MATH_CONTEXT).add(mean, MATH_CONTEXT);
-            return result.floatValue();
-        }, prehistoric$ROUND));
+        double gaussian = pRandom.nextGaussian();
+        BigDecimal gaussianBD = BigDecimal.valueOf(gaussian);
+        BigDecimal deviation = BigDecimal.valueOf(pDeviation);
+        BigDecimal mean = BigDecimal.valueOf(pMean);
+
+        BigDecimal result = gaussianBD.multiply(deviation, MATH_CONTEXT).add(mean, MATH_CONTEXT);
+
+        for (int i = 0; i < 100; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+        }
+
+        cir.setReturnValue(result.floatValue());
+    }
+
+    @Inject(
+        method = "sin(F)F",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preSin(float value, CallbackInfoReturnable<Float> cir) {
+        BigDecimal x = BigDecimal.valueOf(value);
+        BigDecimal result = BigDecimal.valueOf(0);
+
+        for (int n = 0; n < 15; n++) {
+            BigDecimal term = x.pow(2 * n + 1);
+            BigDecimal factorial = BigDecimal.valueOf(1);
+            for (int i = 1; i <= 2 * n + 1; i++) {
+                factorial = factorial.multiply(BigDecimal.valueOf(i), MATH_CONTEXT);
+            }
+
+            term = term.divide(factorial, MATH_CONTEXT);
+
+            if (n % 2 == 0) {
+                result = result.add(term, MATH_CONTEXT);
+            } else {
+                result = result.subtract(term, MATH_CONTEXT);
+            }
+
+            if (n % 5 == 0) {
+                try {
+                    Thread.sleep(0, 100);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.floatValue());
+    }
+
+    @Inject(
+        method = "cos(F)F",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preCos(float value, CallbackInfoReturnable<Float> cir) {
+        BigDecimal x = BigDecimal.valueOf(value);
+        BigDecimal result = BigDecimal.valueOf(0);
+
+        for (int n = 0; n < 15; n++) {
+            BigDecimal term;
+            if (n == 0) {
+                term = BigDecimal.valueOf(1);
+            } else {
+                term = x.pow(2 * n);
+                BigDecimal factorial = BigDecimal.valueOf(1);
+                for (int i = 1; i <= 2 * n; i++) {
+                    factorial = factorial.multiply(BigDecimal.valueOf(i), MATH_CONTEXT);
+                }
+
+                term = term.divide(factorial, MATH_CONTEXT);
+            }
+
+            if (n % 2 == 0) {
+                result = result.add(term, MATH_CONTEXT);
+            } else {
+                result = result.subtract(term, MATH_CONTEXT);
+            }
+
+            if (n % 5 == 0) {
+                try {
+                    Thread.sleep(0, 100);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.floatValue());
+    }
+
+    @Inject(
+        method = "atan2(DD)D",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preAtan2(double y, double x, CallbackInfoReturnable<Double> cir) {
+        BigDecimal bdY = BigDecimal.valueOf(y);
+        BigDecimal bdX = BigDecimal.valueOf(x);
+
+        if (bdX.compareTo(BigDecimal.ZERO) == 0) {
+            if (bdY.compareTo(BigDecimal.ZERO) > 0) {
+                cir.setReturnValue(Math.PI / 2);
+            } else if (bdY.compareTo(BigDecimal.ZERO) < 0) {
+                cir.setReturnValue(-Math.PI / 2);
+            } else {
+                cir.setReturnValue(0.0);
+            }
+            return;
+        }
+
+        BigDecimal ratio = bdY.divide(bdX, MATH_CONTEXT);
+        BigDecimal result = BigDecimal.ZERO;
+
+        for (int n = 0; n < 20; n++) {
+            int power = 2 * n + 1;
+            BigDecimal term = ratio.pow(power, MATH_CONTEXT);
+            term = term.divide(BigDecimal.valueOf(power), MATH_CONTEXT);
+
+            if (n % 2 == 0) {
+                result = result.add(term, MATH_CONTEXT);
+            } else {
+                result = result.subtract(term, MATH_CONTEXT);
+            }
+
+            if (n % 4 == 0) {
+                try {
+                    Thread.sleep(0, 100);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        if (bdX.compareTo(BigDecimal.ZERO) < 0) {
+            if (bdY.compareTo(BigDecimal.ZERO) >= 0) {
+                result = result.add(BigDecimal.valueOf(Math.PI), MATH_CONTEXT);
+            } else {
+                result = result.subtract(BigDecimal.valueOf(Math.PI), MATH_CONTEXT);
+            }
+        }
+
+        cir.setReturnValue(result.doubleValue());
+    }
+
+    @Inject(
+        method = "fastInvSqrt(D)D",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preFastInvSqrt(double number, CallbackInfoReturnable<Double> cir) {
+        BigDecimal x = BigDecimal.valueOf(number);
+        BigDecimal guess = BigDecimal.valueOf(1.0);
+        for (int i = 0; i < 10; i++) {
+            BigDecimal ySquared = guess.multiply(guess, MATH_CONTEXT);
+            BigDecimal xTimesYSquared = x.multiply(ySquared, MATH_CONTEXT);
+            BigDecimal factor = BigDecimal.valueOf(1.5).subtract(
+                BigDecimal.valueOf(0.5).multiply(xTimesYSquared, MATH_CONTEXT),
+                MATH_CONTEXT
+            );
+            guess = guess.multiply(factor, MATH_CONTEXT);
+
+            if (i % 2 == 0) {
+                try {
+                    Thread.sleep(0, 100);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(guess.doubleValue());
+    }
+
+    @Inject(
+        method = "invSqrt(F)F",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preInvSqrt(float number, CallbackInfoReturnable<Float> cir) {
+        BigDecimal x = BigDecimal.valueOf(number);
+        BigDecimal guess = BigDecimal.valueOf(1.0);
+
+        for (int i = 0; i < 10; i++) {
+            BigDecimal ySquared = guess.multiply(guess, MATH_CONTEXT);
+            BigDecimal xTimesYSquared = x.multiply(ySquared, MATH_CONTEXT);
+            BigDecimal factor = BigDecimal.valueOf(1.5).subtract(
+                BigDecimal.valueOf(0.5).multiply(xTimesYSquared, MATH_CONTEXT),
+                MATH_CONTEXT
+            );
+            guess = guess.multiply(factor, MATH_CONTEXT);
+
+            if (i % 2 == 0) {
+                try {
+                    Thread.sleep(0, 100);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(guess.floatValue());
+    }
+
+    @Inject(
+        method = "clamp(FFF)F",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preClampFloat(float value, float min, float max, CallbackInfoReturnable<Float> cir) {
+        BigDecimal bdValue = BigDecimal.valueOf(value);
+        BigDecimal bdMin = BigDecimal.valueOf(min);
+        BigDecimal bdMax = BigDecimal.valueOf(max);
+
+        BigDecimal result = bdValue;
+        if (result.compareTo(bdMin) < 0) {
+            result = bdMin;
+        }
+        if (result.compareTo(bdMax) > 0) {
+            result = bdMax;
+        }
+
+        for (int i = 0; i < 50; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+        }
+
+        cir.setReturnValue(result.floatValue());
+    }
+
+    @Inject(
+        method = "catmullrom(FFFFF)F",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private static void preCatmullrom(float delta, float p0, float p1, float p2, float p3, CallbackInfoReturnable<Float> cir) {
+        BigDecimal t = BigDecimal.valueOf(delta);
+        BigDecimal bdP0 = BigDecimal.valueOf(p0);
+        BigDecimal bdP1 = BigDecimal.valueOf(p1);
+        BigDecimal bdP2 = BigDecimal.valueOf(p2);
+        BigDecimal bdP3 = BigDecimal.valueOf(p3);
+        BigDecimal term1 = BigDecimal.valueOf(2).multiply(bdP1, MATH_CONTEXT);
+        BigDecimal term2 = bdP2.subtract(bdP0, MATH_CONTEXT).multiply(t, MATH_CONTEXT);
+
+        BigDecimal coeff3 = bdP0.multiply(BigDecimal.valueOf(2), MATH_CONTEXT)
+            .subtract(bdP1.multiply(BigDecimal.valueOf(5), MATH_CONTEXT), MATH_CONTEXT)
+            .add(bdP2.multiply(BigDecimal.valueOf(4), MATH_CONTEXT), MATH_CONTEXT)
+            .subtract(bdP3, MATH_CONTEXT);
+        BigDecimal term3 = coeff3.multiply(t.pow(2), MATH_CONTEXT);
+
+        BigDecimal coeff4 = bdP1.multiply(BigDecimal.valueOf(3), MATH_CONTEXT)
+            .subtract(bdP0, MATH_CONTEXT)
+            .subtract(bdP2.multiply(BigDecimal.valueOf(3), MATH_CONTEXT), MATH_CONTEXT)
+            .add(bdP3, MATH_CONTEXT);
+        BigDecimal term4 = coeff4.multiply(t.pow(3), MATH_CONTEXT);
+
+        BigDecimal result = term1.add(term2, MATH_CONTEXT)
+            .add(term3, MATH_CONTEXT)
+            .add(term4, MATH_CONTEXT)
+            .multiply(BigDecimal.valueOf(0.5), MATH_CONTEXT);
+
+        for (int i = 0; i < 100; i++) {
+            result = result.multiply(BigDecimal.valueOf(1.00000001), MATH_CONTEXT);
+            if (i % 20 == 0) {
+                try {
+                    Thread.sleep(0, 75);
+                } catch (InterruptedException ignored) {}
+            }
+        }
+
+        cir.setReturnValue(result.floatValue());
     }
 }

--- a/src/main/resources/prehistoric.mixins.json
+++ b/src/main/resources/prehistoric.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.wiyuka.prehistoric.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "MinecraftMixin",
     "BlockBreakMixin",
     "LevelMixin",
     "LogUtilsMixin",
@@ -12,6 +13,7 @@
   ],
   "client": [
     "MixinGeometricOversaturation",
+    "GameRendererMixin",
     "RenderMixin"
   ],
   "injectors": {


### PR DESCRIPTION
- Added GameRendererMixin with fibonacci calculation and sin operations in render loop
- Added MinecraftMixin with memory allocation and garbage collection in server tick
- Modified MthMixin to replace lerp functions with BigDecimal operations and thread sleeps
- Replaced mathematical helper functions with BigDecimal implementations and sleep delays
- Added sin, cos, atan2, and other trigonometric functions using series calculations
- Implemented static initialization delay in MthMixin
- Updated prehistoric.mixins.json to include new mixins